### PR TITLE
Fix chart tool dependencies and add rendering test

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/src/ai/tools/chart-tool.test.ts
+++ b/src/ai/tools/chart-tool.test.ts
@@ -1,0 +1,36 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+let renderVegaLiteToPngDataUrl: typeof import('./chart-tool')['renderVegaLiteToPngDataUrl'];
+
+beforeAll(async () => {
+  process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY ?? 'test-api-key';
+  process.env.NEXT_PUBLIC_SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'http://localhost:54321';
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? 'anon-key';
+
+  ({ renderVegaLiteToPngDataUrl } = await import('./chart-tool'));
+});
+
+const simpleSpec = {
+  width: 200,
+  height: 200,
+  data: {
+    values: [
+      { category: 'A', value: 1 },
+      { category: 'B', value: 2 },
+    ],
+  },
+  mark: 'bar',
+  encoding: {
+    x: { field: 'category', type: 'nominal' },
+    y: { field: 'value', type: 'quantitative' },
+  },
+};
+
+describe('renderVegaLiteToPngDataUrl', () => {
+  it('returns a PNG data URL for a minimal spec', async () => {
+    const dataUrl = await renderVegaLiteToPngDataUrl(simpleSpec);
+
+    expect(dataUrl.startsWith('data:image/png;base64,')).toBe(true);
+    expect(dataUrl.length).toBeGreaterThan(1000);
+  });
+});

--- a/src/components/history-panel.tsx
+++ b/src/components/history-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ScrollArea } from "@/src/components/ui/scroll-area";
-import type { Conversation } from '@/src/components/dashboard';
+import type { Conversation } from '@/src/lib/types';
 import { Button } from "@/src/components/ui/button";
 import { cn } from "@/src/lib/utils";
 

--- a/src/components/sql-tool-panel.tsx
+++ b/src/components/sql-tool-panel.tsx
@@ -12,7 +12,7 @@ import { Button } from '@/src/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/src/components/ui/card";
 import { Loader2, Play } from 'lucide-react';
 import { DataTable } from './data-table';
-import { useToast } from '@/hooks/use-toast';
+import { useToast } from '@/src/hooks/use-toast';
 
 const formSchema = z.object({
   query: z.string().min(1, 'Query cannot be empty.'),

--- a/src/components/user-nav.tsx
+++ b/src/components/user-nav.tsx
@@ -9,8 +9,8 @@ import {
   Avatar,
   AvatarFallback,
   AvatarImage,
-} from "@/components/ui/avatar"
-import { Button } from "@/components/ui/button"
+} from "@/src/components/ui/avatar"
+import { Button } from "@/src/components/ui/button"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -19,8 +19,8 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
-import { useToast } from "@/hooks/use-toast";
+} from "@/src/components/ui/dropdown-menu"
+import { useToast } from "@/src/hooks/use-toast";
 import { LogOut, User as UserIcon } from "lucide-react";
 
 interface UserNavProps {
@@ -33,6 +33,15 @@ export function UserNav({ user }: UserNavProps) {
 
   const handleLogout = async () => {
     try {
+      if (!auth) {
+        toast({
+          variant: "destructive",
+          title: "Logout Failed",
+          description: "Firebase ist nicht konfiguriert.",
+        });
+        return;
+      }
+
       await signOut(auth);
       toast({
         title: "Logged Out",

--- a/src/scripts/embed-codebook.ts
+++ b/src/scripts/embed-codebook.ts
@@ -4,7 +4,6 @@
 import { config } from 'dotenv';
 import { createClient } from '@supabase/supabase-js';
 import * as fs from 'fs/promises';
-import { RecursiveCharacterTextSplitter } from 'langchain/text_splitter';
 import { OpenAIEmbeddings } from '@langchain/openai';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -28,6 +27,47 @@ const embeddings = new OpenAIEmbeddings({
   model: 'text-embedding-3-small',
 });
 
+type DocumentChunk = {
+  pageContent: string;
+  metadata: { chunk: number; start: number };
+};
+
+function splitTextIntoChunks(
+  text: string,
+  { chunkSize = 1000, chunkOverlap = 100 }: { chunkSize?: number; chunkOverlap?: number } = {}
+): DocumentChunk[] {
+  if (chunkSize <= 0) {
+    throw new Error('chunkSize must be greater than 0');
+  }
+
+  const step = chunkSize - chunkOverlap;
+
+  if (step <= 0) {
+    throw new Error('chunkOverlap must be smaller than chunkSize');
+  }
+
+  const chunks: DocumentChunk[] = [];
+  let start = 0;
+  let index = 0;
+
+  while (start < text.length) {
+    const end = Math.min(text.length, start + chunkSize);
+    const pageContent = text.slice(start, end).trim();
+
+    if (pageContent.length > 0) {
+      chunks.push({
+        pageContent,
+        metadata: { chunk: index, start },
+      });
+    }
+
+    start += step;
+    index += 1;
+  }
+
+  return chunks;
+}
+
 async function main() {
   console.log('Starting codebook embedding process...');
 
@@ -42,11 +82,7 @@ async function main() {
 
     // 2. Split the text into chunks
     console.log('Splitting text into chunks...');
-    const splitter = new RecursiveCharacterTextSplitter({
-      chunkSize: 1000,
-      chunkOverlap: 100,
-    });
-    const chunks = await splitter.createDocuments([content]);
+    const chunks = splitTextIntoChunks(content, { chunkSize: 1000, chunkOverlap: 100 });
     console.log(`Created ${chunks.length} document chunks.`);
 
     // 3. Clear existing documents in the table

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "baseUrl": ".",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
## Summary
- add a baseUrl to the TS config so path aliases resolve consistently
- fix imports relying on those aliases and harden the user logout flow when Firebase is unconfigured
- replace the LangChain text splitter dependency with a local chunker and add a Vega-Lite rendering smoke test to verify the chart tool
- introduce a minimal ESLint config to avoid interactive prompts when running lint

## Testing
- yarn typecheck
- yarn test --run
- yarn lint *(fails: ESLint package is not installed in the workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68cac520e9e483329ab7c4e4803eb740