### PR TITLE
Keep bar labels aligned with sort order

### DIFF
--- a/src/ai/tools/chart-tool.test.ts
+++ b/src/ai/tools/chart-tool.test.ts
@@ -8,13 +8,14 @@ vi.mock('@/src/ai/genkit', () => ({
 }));
 
 let renderVegaLiteToPngDataUrl: typeof import('./chart-tool')['renderVegaLiteToPngDataUrl'];
+let buildBarChartEntries: typeof import('./chart-tool')['buildBarChartEntries'];
 
 beforeAll(async () => {
   process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY ?? 'test-api-key';
   process.env.NEXT_PUBLIC_SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'http://localhost:54321';
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? 'anon-key';
 
-  ({ renderVegaLiteToPngDataUrl } = await import('./chart-tool'));
+  ({ renderVegaLiteToPngDataUrl, buildBarChartEntries } = await import('./chart-tool'));
 });
 
 const simpleSpec = {
@@ -39,5 +40,24 @@ describe('renderVegaLiteToPngDataUrl', () => {
 
     expect(dataUrl.startsWith('data:image/png;base64,')).toBe(true);
     expect(dataUrl.length).toBeGreaterThan(1000);
+  });
+});
+
+describe('buildBarChartEntries', () => {
+  it('keeps labels aligned with categorical sort order', () => {
+    const encoding = {
+      x: { field: 'category', type: 'nominal', sort: '-y' },
+      y: { field: 'value', type: 'quantitative' },
+    };
+    const values = [
+      { category: 'Alpha', value: 2 },
+      { category: 'Gamma', value: 1 },
+      { category: 'Beta', value: 5 },
+    ];
+
+    const entries = buildBarChartEntries(values, encoding, 'vertical');
+
+    expect(entries.map((entry) => entry.value)).toEqual([5, 2, 1]);
+    expect(entries.map((entry) => entry.label)).toEqual(['BETA', 'ALPHA', 'GAMMA']);
   });
 });

--- a/src/ai/tools/chart-tool.ts
+++ b/src/ai/tools/chart-tool.ts
@@ -336,6 +336,60 @@ function renderWithFallback(spec: any): string {
   return `data:image/png;base64,${png.toString('base64')}`;
 }
 
+export type BarChartEntry = {
+  category: string;
+  label: string;
+  value: number;
+};
+
+export function buildBarChartEntries(
+  dataValues: any[],
+  encoding: EncodingConfig,
+  orientation: 'vertical' | 'horizontal',
+): BarChartEntry[] {
+  const xEnc = encoding.x ?? {};
+  const yEnc = encoding.y ?? {};
+
+  const valueField = orientation === 'vertical' ? yEnc.field ?? 'value' : xEnc.field ?? 'value';
+  const categoryField =
+    orientation === 'vertical' ? xEnc.field ?? 'category' : yEnc.field ?? 'category';
+
+  const entries = dataValues
+    .map((row: any) => {
+      const rawCategory = categoryField != null ? row?.[categoryField] : undefined;
+      const rawValue =
+        valueField != null ? row?.[valueField] : row?.value ?? row?.count ?? row?.total;
+      const numericValue =
+        typeof rawValue === 'number'
+          ? rawValue
+          : typeof rawValue === 'string' && looksNumeric(rawValue)
+          ? parseFloat(rawValue)
+          : NaN;
+      const category =
+        rawCategory == null
+          ? ''
+          : typeof rawCategory === 'string'
+          ? rawCategory
+          : String(rawCategory);
+      const label = sanitizeLabel(category) || 'N/A';
+      return {
+        category,
+        label,
+        value: numericValue,
+      };
+    })
+    .filter((entry) => Number.isFinite(entry.value));
+
+  const catEnc = orientation === 'vertical' ? xEnc : yEnc;
+  const sortDirective = typeof catEnc.sort === 'string' ? catEnc.sort : undefined;
+  if (sortDirective) {
+    const descending = sortDirective.startsWith('-');
+    entries.sort((a, b) => (descending ? b.value - a.value : a.value - b.value));
+  }
+
+  return entries;
+}
+
 function renderBarChartFallback(
   buffer: PixelBuffer,
   dataValues: any[],
@@ -361,44 +415,10 @@ function renderBarChartFallback(
     orientation = 'horizontal';
   }
 
-  const valueField = orientation === 'vertical' ? yEnc.field ?? 'value' : xEnc.field ?? 'value';
-  const categoryField =
-    orientation === 'vertical' ? xEnc.field ?? 'category' : yEnc.field ?? 'category';
-
-  const entries = dataValues
-    .map((row: any) => {
-      const rawCategory = categoryField != null ? row?.[categoryField] : undefined;
-      const rawValue =
-        valueField != null ? row?.[valueField] : row?.value ?? row?.count ?? row?.total;
-      const numericValue =
-        typeof rawValue === 'number'
-          ? rawValue
-          : typeof rawValue === 'string' && looksNumeric(rawValue)
-          ? parseFloat(rawValue)
-          : NaN;
-      return {
-        category:
-          rawCategory == null
-            ? ''
-            : typeof rawCategory === 'string'
-            ? rawCategory
-            : String(rawCategory),
-        value: numericValue,
-      };
-    })
-    .filter((entry) => Number.isFinite(entry.value));
+  const entries = buildBarChartEntries(dataValues, encoding, orientation);
 
   if (!entries.length) {
     throw new Error('Keine numerischen Daten für das Rendering gefunden.');
-  }
-
-  const categoryLabels = entries.map((entry) => sanitizeLabel(entry.category) || 'N/A');
-
-  const catEnc = orientation === 'vertical' ? xEnc : yEnc;
-  const sortDirective = typeof catEnc.sort === 'string' ? catEnc.sort : undefined;
-  if (sortDirective) {
-    const descending = sortDirective.startsWith('-');
-    entries.sort((a, b) => (descending ? b.value - a.value : a.value - b.value));
   }
 
   const innerWidth = Math.max(20, width - margin.left - margin.right);
@@ -469,7 +489,7 @@ function renderBarChartFallback(
         buffer,
         x0 + barSize / 2,
         originY + 18,
-        shortenLabel(categoryLabels[index]),
+        shortenLabel(entry.label),
         TEXT_COLOR,
         1,
         'center',
@@ -493,7 +513,7 @@ function renderBarChartFallback(
         buffer,
         originX - 12,
         y0 + barSize / 2,
-        shortenLabel(categoryLabels[index]),
+        shortenLabel(entry.label),
         TEXT_COLOR,
         1,
         'right',


### PR DESCRIPTION
## Summary
- add a reusable helper that prepares sorted bar chart entries with sanitized labels
- update the fallback renderer to consume the helper and keep labels aligned with sorted data
- cover the helper with a regression test that verifies categorical sort preserves label order

## Testing
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68cb9ae2a8e483329605d30ca3b4438f