### PR TITLE
Fix Genkit OpenAI plugin loader

### DIFF
--- a/src/ai/genkit.ts
+++ b/src/ai/genkit.ts
@@ -1,10 +1,6 @@
 
 import { createRequire } from 'node:module';
-
 import { genkit } from 'genkit';
-
-
-const { createRequire } = moduleModule;
 
 const moduleSpecifier = '@genkit-ai/compat-oai/openai';
 
@@ -38,16 +34,11 @@ const { plugin: openAiPluginFactory, error: openAiLoadError } = await (async () 
   };
 
   try {
-    const { createRequire } = await import('node:module');
-    try {
-      const requireForCompat = createRequire(import.meta.url);
-      const mod = requireForCompat(moduleSpecifier);
-      const plugin = normalizeModule(mod);
-      if (plugin) {
-        return { plugin, error: detectedError };
-      }
-    } catch (error) {
-      recordError(error);
+    const requireForCompat = createRequire(import.meta.url);
+    const mod = requireForCompat(moduleSpecifier);
+    const plugin = normalizeModule(mod);
+    if (plugin) {
+      return { plugin, error: detectedError };
     }
   } catch (error) {
     recordError(error);


### PR DESCRIPTION
## Summary
- fix the Genkit OpenAI plugin loader to use the imported createRequire helper and remove the stray undefined reference
- keep the fallback dynamic import path while properly recording load errors for diagnostics

## Testing
- yarn lint *(fails: ESLint must be installed: yarn add --dev eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68ccfbd2364483329ff0385a3fd5a049