### PR TITLE
Handle additional OpenAI plugin export shapes

### DIFF
--- a/src/ai/genkit.ts
+++ b/src/ai/genkit.ts
@@ -29,8 +29,16 @@ const { plugin: openAiPluginFactory, error: openAiLoadError } = await (async () 
   };
 
   const normalizeModule = (mod: any): OpenAiPluginFactory | null => {
-    const candidate = mod?.default ?? mod;
-    return typeof candidate === 'function' ? candidate : null;
+    const candidates = [
+      mod?.default,
+      mod?.plugin,
+      mod?.openai,
+      mod?.openAi,
+      mod?.OpenAI,
+      mod,
+    ];
+    const candidate = candidates.find((entry) => typeof entry === 'function');
+    return candidate ?? null;
   };
 
   try {


### PR DESCRIPTION
## Summary
- broaden the Genkit OpenAI plugin loader so it recognises default, named, and plugin exports when initialising

## Testing
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68ccfcd19df08332a49c1b3196ef218a