### PR TITLE
Add visualization tooling for chat-generated charts

### DIFF
--- a/src/ai/flows/main-assistant-flow.ts
+++ b/src/ai/flows/main-assistant-flow.ts
@@ -17,6 +17,8 @@ import { z } from 'zod';
 import { executeQueryTool } from '@/src/ai/tools/sql-query-tool';
 import { searchCodebook } from '@/src/lib/vector-search';
 import { statisticsTool } from '@/src/ai/tools/statistics-tool';
+import { visualizationTool } from '@/src/ai/tools/visualization-tool';
+import { ChartDefinitionSchema, type ChartDefinition } from '@/src/lib/types';
 
 const MessageSchema = z.object({
   role: z.enum(['user', 'assistant', 'tool']),
@@ -33,6 +35,7 @@ const MainAssistantOutputSchema = z.object({
   answer: z.string().describe('The final answer to be displayed to the user.'),
   sqlQuery: z.string().optional().describe('The SQL query that was executed.'),
   retrievedContext: z.string().optional().describe('The context retrieved from the vector database.'),
+  chart: ChartDefinitionSchema.optional().describe('Optional chart configuration for visualization.'),
 });
 export type MainAssistantOutput = z.infer<typeof MainAssistantOutputSchema>;
 
@@ -124,6 +127,7 @@ CODEBOOK CONTEXT (authoritative variable names):
 ${retrievedContext}`;
 
     let statsOutput: any | null = null;
+    let chartDefinition: ChartDefinition | undefined;
     try {
       const statsExtraction = await ai.generate({
         model: 'openai/gpt-4o',
@@ -160,6 +164,7 @@ Write a clear, user-friendly answer based on the regression result. If there was
           answer,
           sqlQuery: String(statsOutput?.sqlQuery || ''), // SQL aus statisticsTool, falls vorhanden
           retrievedContext,
+          chart: undefined,
         };
       }
     } catch (e) {
@@ -172,6 +177,34 @@ Write a clear, user-friendly answer based on the regression result. If there was
     const toolOutput = await executeQueryTool({ nlQuestion: reformulatedQuestion, history: input.history });
     console.log('[mainAssistantFlow] Tool output received:', JSON.stringify(toolOutput, null, 2));
 
+    const visualizationRegex = /(visualis|diagram|plot|chart|graph|grafik|visualize|visualization|diagramm)/i;
+    const wantsVisualization =
+      visualizationRegex.test(input.question) ||
+      visualizationRegex.test(reformulatedQuestion);
+
+    if (
+      wantsVisualization &&
+      Array.isArray(toolOutput.data) &&
+      toolOutput.data.length > 0
+    ) {
+      try {
+        const plan = await visualizationTool({
+          question: reformulatedQuestion,
+          dataPreview: toolOutput.data.slice(0, 20),
+        });
+        chartDefinition = {
+          ...plan,
+          data: toolOutput.data.slice(0, 100),
+        };
+        console.log('[mainAssistantFlow] Visualization plan created:', chartDefinition);
+      } catch (visualizationError) {
+        console.warn(
+          '[mainAssistantFlow] Visualization tool failed, proceeding without chart:',
+          visualizationError,
+        );
+      }
+    }
+
     const finalPrompt = `You are an expert data analyst and assistant for the European Social Survey (ESS).
 You have just executed a query to answer the user's question.
 
@@ -180,6 +213,25 @@ The reformulated question used for the query: "${reformulatedQuestion}"
 
 Here is the result from the database tool:
 ${JSON.stringify(toolOutput, null, 2)}
+
+${
+  chartDefinition
+    ? `A chart configuration has also been prepared to visualize the findings:
+${JSON.stringify(
+        {
+          type: chartDefinition.type,
+          xKey: chartDefinition.xKey,
+          series: chartDefinition.series,
+          title: chartDefinition.title,
+          description: chartDefinition.description,
+          dataPoints: chartDefinition.data.length,
+        },
+        null,
+        2,
+      )}
+Describe this visualization in your response.`
+    : 'No chart configuration was generated.'
+}
 
 Now, formulate a final, user-friendly answer based on the tool's output. If there was an error, state it clearly and suggest next steps.`;
 
@@ -190,6 +242,7 @@ Now, formulate a final, user-friendly answer based on the tool's output. If ther
       answer,
       sqlQuery: String(toolOutput.sqlQuery || ''),
       retrievedContext,
+      chart: chartDefinition,
     };
   }
 );

--- a/src/ai/tools/visualization-tool.ts
+++ b/src/ai/tools/visualization-tool.ts
@@ -1,0 +1,63 @@
+'use server';
+
+import { ai } from '@/src/ai/genkit';
+import { z } from 'zod';
+
+const chartSeriesSchema = z.object({
+  key: z.string().describe('The data field to visualize.'),
+  label: z.string().optional().describe('Human friendly name for the series.'),
+});
+
+const chartPlanSchema = z.object({
+  type: z.enum(['bar', 'line', 'area', 'pie']).describe('Preferred visualization type.'),
+  xKey: z.string().describe('Field to use for the horizontal axis or category.'),
+  series: z.array(chartSeriesSchema).min(1).describe('One or more data series to render.'),
+  title: z.string().optional().describe('Suggested title for the chart.'),
+  description: z.string().optional().describe('Short narrative explaining what the chart shows.'),
+});
+
+const toolInputSchema = z.object({
+  question: z.string().describe('Original natural language question requesting the visualization.'),
+  dataPreview: z
+    .array(z.record(z.any()))
+    .min(1)
+    .max(20)
+    .describe('Preview of the tabular data that should be visualized.'),
+});
+
+export type VisualizationPlan = z.infer<typeof chartPlanSchema>;
+
+export const visualizationTool = ai.defineTool(
+  {
+    name: 'visualizationTool',
+    description:
+      'Design a professional data visualization that best communicates the provided dataset in the context of the user question.',
+    inputSchema: toolInputSchema,
+    outputSchema: chartPlanSchema,
+  },
+  async (input) => {
+    const prompt = `You are a senior data visualization designer. Create a clear and professional chart specification.
+
+USER QUESTION:
+${input.question}
+
+DATA PREVIEW (first rows from SQL result):
+${JSON.stringify(input.dataPreview, null, 2)}
+
+REQUIREMENTS:
+- Pick the most appropriate chart type among bar, line, area, or pie.
+- Use column names exactly as they appear in the data preview.
+- Respond strictly as JSON that matches the provided schema.
+- Prefer grouped/stacked charts if multiple metrics share the same categories.
+- Provide a concise title and description when helpful.
+`;
+
+    const response = await ai.generate({
+      model: 'openai/gpt-4o',
+      prompt,
+      output: { schema: chartPlanSchema },
+    });
+
+    return response.output!;
+  },
+);

--- a/src/components/ask-ai-panel.tsx
+++ b/src/components/ask-ai-panel.tsx
@@ -17,6 +17,7 @@ import { type Conversation, type Message } from '@/src/lib/types';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/src/components/ui/accordion';
 import { Code2, Database } from 'lucide-react';
 import Logo from '@/src/components/logo';
+import { ChatVisualization } from '@/src/components/chat-visualization';
 
 const formSchema = z.object({
   question: z.string().min(1, 'Question cannot be empty.'),
@@ -65,6 +66,7 @@ export default function AskAiPanel({ conversation, onMessagesUpdate }: AskAiPane
         content: result.answer,
         sqlQuery: result.sqlQuery,
         retrievedContext: result.retrievedContext,
+        chart: result.chart,
       };
       
       const finalMessages = [...newMessages, assistantMessage];
@@ -99,6 +101,11 @@ export default function AskAiPanel({ conversation, onMessagesUpdate }: AskAiPane
               )}
               <div className={`rounded-lg p-3 max-w-[80%] ${message.role === 'user' ? 'bg-primary text-primary-foreground' : 'bg-muted'}`}>
               <div className="text-sm whitespace-pre-wrap">{message.content}</div>
+                {message.chart && (
+                  <div className="mt-3 rounded-lg border bg-background/70 p-3">
+                    <ChatVisualization chart={message.chart} />
+                  </div>
+                )}
                 {(message.sqlQuery || message.retrievedContext) && (
                    <Accordion type="single" collapsible className="w-full mt-2">
                       <AccordionItem value="details" className='border-0'>

--- a/src/components/chat-visualization.tsx
+++ b/src/components/chat-visualization.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import React from 'react';
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+} from '@/src/components/ui/chart';
+import { CartesianGrid, XAxis, YAxis, BarChart, Bar, LineChart, Line, AreaChart, Area, PieChart, Pie, Cell } from 'recharts';
+import type { ChartDefinition } from '@/src/lib/types';
+import { cn } from '@/src/lib/utils';
+
+const chartPalette = [
+  'hsl(var(--chart-1))',
+  'hsl(var(--chart-2))',
+  'hsl(var(--chart-3))',
+  'hsl(var(--chart-4))',
+  'hsl(var(--chart-5))',
+];
+
+function humanize(label: string): string {
+  return label
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^\w/g, (char) => char.toUpperCase());
+}
+
+function buildChartConfig(chart: ChartDefinition) {
+  return chart.series.reduce<Record<string, { label?: React.ReactNode; color?: string }>>(
+    (acc, series, index) => {
+      acc[series.key] = {
+        label: series.label ?? humanize(series.key),
+        color: chartPalette[index % chartPalette.length],
+      };
+      return acc;
+    },
+    {},
+  );
+}
+
+function normalizeData(chart: ChartDefinition) {
+  return chart.data.map((row) => {
+    const normalized: Record<string, unknown> = { ...row };
+    chart.series.forEach((series) => {
+      const value = (row as Record<string, unknown>)[series.key];
+      if (typeof value === 'string') {
+        const numeric = Number(value);
+        if (!Number.isNaN(numeric)) {
+          normalized[series.key] = numeric;
+        }
+      }
+    });
+    return normalized;
+  });
+}
+
+interface ChatVisualizationProps {
+  chart: ChartDefinition;
+  className?: string;
+}
+
+export function ChatVisualization({ chart, className }: ChatVisualizationProps) {
+  const config = React.useMemo(() => buildChartConfig(chart), [chart]);
+  const data = React.useMemo(() => normalizeData(chart), [chart]);
+
+  const renderCartesian = (type: 'bar' | 'line' | 'area') => {
+    const commonAxes = (
+      <>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} />
+        <XAxis dataKey={chart.xKey} tickLine={false} axisLine={false} />
+        <YAxis tickLine={false} axisLine={false} width={48} />
+        <ChartTooltip cursor={{ opacity: 0.2 }} content={<ChartTooltipContent />} />
+        <ChartLegend content={<ChartLegendContent />} />
+      </>
+    );
+
+    if (type === 'bar') {
+      return (
+        <BarChart data={data}>
+          {commonAxes}
+          {chart.series.map((series) => (
+            <Bar
+              key={series.key}
+              dataKey={series.key}
+              fill={`var(--color-${series.key})`}
+              radius={4}
+              maxBarSize={64}
+            />
+          ))}
+        </BarChart>
+      );
+    }
+
+    if (type === 'line') {
+      return (
+        <LineChart data={data}>
+          {commonAxes}
+          {chart.series.map((series) => (
+            <Line
+              key={series.key}
+              type="monotone"
+              dataKey={series.key}
+              stroke={`var(--color-${series.key})`}
+              strokeWidth={2}
+              dot={false}
+            />
+          ))}
+        </LineChart>
+      );
+    }
+
+    return (
+      <AreaChart data={data}>
+        {commonAxes}
+        {chart.series.map((series) => (
+          <Area
+            key={series.key}
+            type="monotone"
+            dataKey={series.key}
+            fill={`var(--color-${series.key})`}
+            stroke={`var(--color-${series.key})`}
+            fillOpacity={0.3}
+          />
+        ))}
+      </AreaChart>
+    );
+  };
+
+  const renderPie = () => {
+    const [series] = chart.series;
+    return (
+      <PieChart>
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartLegend content={<ChartLegendContent />} />
+        <Pie
+          data={data}
+          dataKey={series.key}
+          nameKey={chart.xKey}
+          innerRadius={40}
+          outerRadius={80}
+          paddingAngle={2}
+        >
+          {data.map((_, index) => (
+            <Cell
+              key={`cell-${index}`}
+              fill={chartPalette[index % chartPalette.length]}
+              stroke="var(--border)"
+            />
+          ))}
+        </Pie>
+      </PieChart>
+    );
+  };
+
+  return (
+    <div className={cn('space-y-2', className)}>
+      {(chart.title || chart.description) && (
+        <div className="space-y-1 text-left">
+          {chart.title && <h4 className="font-semibold text-sm leading-tight">{chart.title}</h4>}
+          {chart.description && (
+            <p className="text-xs text-muted-foreground leading-snug">{chart.description}</p>
+          )}
+        </div>
+      )}
+      <ChartContainer config={config} className="w-full">
+        {chart.type === 'pie' ? renderPie() : renderCartesian(chart.type)}
+      </ChartContainer>
+    </div>
+  );
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,20 @@
 import { z } from 'zod';
 
+export const ChartSeriesSchema = z.object({
+  key: z.string(),
+  label: z.string().optional(),
+});
+
+export const ChartDefinitionSchema = z.object({
+  type: z.enum(['bar', 'line', 'area', 'pie']),
+  xKey: z.string(),
+  series: z.array(ChartSeriesSchema).min(1),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  data: z.array(z.record(z.any())).default([]),
+});
+export type ChartDefinition = z.infer<typeof ChartDefinitionSchema>;
+
 /**
  * Defines the structure for a single message in a conversation.
  * This is used for both client-side state management and server-side AI processing.
@@ -9,6 +24,7 @@ export const MessageSchema = z.object({
   content: z.string(),
   sqlQuery: z.string().optional(),
   retrievedContext: z.string().optional(),
+  chart: ChartDefinitionSchema.optional(),
 });
 export type Message = z.infer<typeof MessageSchema>;
 


### PR DESCRIPTION
## Summary
- extend the main assistant flow to detect visualization prompts, create chart specifications, and return them with the response
- add a visualization tool plus a reusable chat visualization component to render charts for assistant messages
- update shared message types so chart metadata travels from the AI response to the UI

## Testing
- yarn lint *(fails: `next lint` prompts for interactive configuration in this repository)*
- yarn typecheck *(fails: existing unresolved module path/type errors in unrelated files)*
- yarn test *(terminated after Vitest reported no test files and awaited input)*

------
https://chatgpt.com/codex/tasks/task_e_68cee16bebc08332915eaa5dfdfad50e