### PR TITLE
Fix Next scripts for Firebase preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "node ./node_modules/next/dist/bin/next dev",
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint",
+    "build": "node ./node_modules/next/dist/bin/next build",
+    "start": "node ./node_modules/next/dist/bin/next start",
+    "lint": "node ./node_modules/next/dist/bin/next lint",
     "typecheck": "tsc --noEmit",
     "embed": "tsx src/scripts/embed-codebook.ts",
     "test": "vitest"


### PR DESCRIPTION
## Summary
- update Next.js npm scripts to invoke the CLI via node_modules so the binary is always found during Firebase previews

## Testing
- attempted `npm run lint` (command aborted because Next.js prompted for ESLint config interactively)

------
https://chatgpt.com/codex/tasks/task_e_68cf179586388332b8a9327172a616f5