### PR TITLE
Fix main assistant invocation from client

### DIFF
--- a/src/ai/flows/main-assistant-flow.ts
+++ b/src/ai/flows/main-assistant-flow.ts
@@ -25,13 +25,13 @@ const MessageSchema = z.object({
   content: z.string(),
 });
 
-const MainAssistantInputSchema = z.object({
+export const MainAssistantInputSchema = z.object({
   question: z.string().describe("The user's current question."),
   history: z.array(MessageSchema).optional().describe("The conversation history."),
 });
 export type MainAssistantInput = z.infer<typeof MainAssistantInputSchema>;
 
-const MainAssistantOutputSchema = z.object({
+export const MainAssistantOutputSchema = z.object({
   answer: z.string().describe('The final answer to be displayed to the user.'),
   sqlQuery: z.string().optional().describe('The SQL query that was executed.'),
   retrievedContext: z.string().optional().describe('The context retrieved from the vector database.'),

--- a/src/app/api/main-assistant/route.ts
+++ b/src/app/api/main-assistant/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { MainAssistantInputSchema, mainAssistant } from '@/src/ai/flows/main-assistant-flow';
+
+export async function POST(request: Request) {
+  try {
+    const json = await request.json();
+    const parsed = MainAssistantInputSchema.safeParse(json);
+
+    if (!parsed.success) {
+      console.error('[main-assistant API] Invalid request payload:', parsed.error.flatten());
+      return NextResponse.json({ error: 'Invalid request payload.' }, { status: 400 });
+    }
+
+    const result = await mainAssistant(parsed.data);
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error('[main-assistant API] Unexpected error:', error);
+    return NextResponse.json({ error: 'Internal server error.' }, { status: 500 });
+  }
+}

--- a/src/components/ask-ai-panel.tsx
+++ b/src/components/ask-ai-panel.tsx
@@ -5,7 +5,6 @@ import { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
-import { mainAssistant } from '@/src/ai/flows/main-assistant-flow';
 
 import { Form, FormControl, FormField, FormItem } from '@/src/components/ui/form';
 import { Input } from '@/src/components/ui/input';
@@ -53,11 +52,23 @@ export default function AskAiPanel({ conversation, onMessagesUpdate }: AskAiPane
     try {
       // Pass only the essential parts of the history, excluding context and queries
       const historyForApi = messages.map(({ role, content }) => ({ role, content }));
-      
-      const result = await mainAssistant({ 
-        question: values.question, 
-        history: historyForApi
+
+      const response = await fetch('/api/main-assistant', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          question: values.question,
+          history: historyForApi,
+        }),
       });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        throw new Error(result?.error ?? 'Failed to fetch assistant response.');
+      }
 
       console.log('[AskAiPanel] Result from mainAssistant:', result); // <--- HIER
 


### PR DESCRIPTION
## Summary
- expose the main assistant input/output schemas for reuse on the server
- add an API route that proxies requests to the main assistant flow with validation
- update the Ask AI panel to call the new API endpoint instead of importing the server action directly

## Testing
- yarn lint *(fails: ESLint is not installed in the environment)*
- yarn test


------
https://chatgpt.com/codex/tasks/task_e_68d03db92530833288d3c80be4dba4ac