### PR TITLE
fix: remove server directive from main assistant flow

### DIFF
--- a/src/ai/flows/main-assistant-flow.ts
+++ b/src/ai/flows/main-assistant-flow.ts
@@ -1,4 +1,3 @@
-'use server';
 /**
  * @fileOverview The main AI assistant agent.
  *


### PR DESCRIPTION
## Summary
- remove the `"use server"` directive from the main assistant flow so the module exports are valid for Next.js

## Testing
- yarn lint *(fails: ESLint not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0417a48b08332b3b04bfb8c61c2bf