### PR TITLE
Fix ask AI panel history payload

### DIFF
--- a/src/components/ask-ai-panel.tsx
+++ b/src/components/ask-ai-panel.tsx
@@ -54,7 +54,11 @@ export default function AskAiPanel({ conversation, onMessagesUpdate }: AskAiPane
 
     try {
       // Pass only the essential parts of the history, excluding context and queries
-      const historyForApi = messages.map(({ role, content }) => ({ role, content }));
+      // Include the latest user prompt when sending the conversation history to the API.
+      // Using the local `newMessages` array ensures the freshly added user question
+      // is part of the request payload instead of relying on the slightly stale
+      // `messages` state snapshot captured prior to calling `setMessages`.
+      const historyForApi = newMessages.map(({ role, content }) => ({ role, content }));
 
       const response = await fetch('/api/main-assistant', {
         method: 'POST',


### PR DESCRIPTION
## Summary
- ensure the Ask AI panel sends the freshly submitted user prompt in the history payload when calling the main assistant API
- document why the `newMessages` array is used instead of the stale `messages` state snapshot

## Testing
- yarn lint *(fails: ESLint dependency missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0da65c5d48332a63d7f30f2fc246b