### PR TITLE
Handle assistant error responses gracefully

### DIFF
--- a/src/components/ask-ai-panel.tsx
+++ b/src/components/ask-ai-panel.tsx
@@ -91,6 +91,14 @@ export default function AskAiPanel({ conversation, onMessagesUpdate }: AskAiPane
         throw new Error('Assistant response was empty. Please try again.');
       }
 
+      if ('error' in result && result.error) {
+        const message =
+          typeof result.error === 'string'
+            ? result.error
+            : 'Assistant service reported an unknown error.';
+        throw new Error(message);
+      }
+
       if (!('answer' in result) || typeof result.answer !== 'string') {
         throw new Error('Assistant response was missing the final answer.');
       }


### PR DESCRIPTION
## Summary
- surface assistant API error messages in the Ask AI panel by checking for error payloads before processing answers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0db60f3d483329004ded1955a27cd