### PR TITLE
Improve AskAiPanel error handling

### DIFF
--- a/src/components/ask-ai-panel.tsx
+++ b/src/components/ask-ai-panel.tsx
@@ -49,6 +49,7 @@ export default function AskAiPanel({ conversation, onMessagesUpdate }: AskAiPane
     const userMessage: Message = { role: 'user', content: values.question };
     const newMessages = [...messages, userMessage];
     setMessages(newMessages);
+    onMessagesUpdate(conversation.id, newMessages);
     setIsLoading(true);
     form.reset();
 
@@ -121,7 +122,9 @@ export default function AskAiPanel({ conversation, onMessagesUpdate }: AskAiPane
 
     } catch (error) {
       console.error(error);
-      const errorMessage: Message = { role: 'assistant', content: 'Sorry, I encountered an error. Please try again.' };
+      const fallbackError = 'Sorry, I encountered an error. Please try again.';
+      const errorText = error instanceof Error && error.message ? error.message : fallbackError;
+      const errorMessage: Message = { role: 'assistant', content: errorText };
       const finalMessages = [...newMessages, errorMessage];
       setMessages(finalMessages);
       onMessagesUpdate(conversation.id, finalMessages);


### PR DESCRIPTION
## Summary
- update AskAiPanel to synchronise parent conversation state immediately when the user submits a message
- surface API failure messages to the UI instead of a generic fallback while keeping a default message as backup

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68d0de23226c83329a8ec84e57da657a