### PR TITLE
Improve chart visualization flexibility

### DIFF
--- a/src/ai/tools/visualization-tool.ts
+++ b/src/ai/tools/visualization-tool.ts
@@ -6,11 +6,32 @@ import { z } from 'zod';
 const chartSeriesSchema = z.object({
   key: z.string().describe('The data field to visualize.'),
   label: z.string().optional().describe('Human friendly name for the series.'),
+  dataKey: z
+    .string()
+    .optional()
+    .describe(
+      'Optional raw field to read values from when the displayed key should differ from the column name.',
+    ),
+  color: z.string().optional().describe('Preferred CSS color token (hex, rgb, hsl) for the series.'),
+  axis: z
+    .enum(['left', 'right'])
+    .optional()
+    .describe('Selects which Y-axis to map the series to for dual-axis charts.'),
+  stackId: z
+    .string()
+    .optional()
+    .describe('Stack identifier used to combine related series in stacked charts.'),
 });
 
 const chartPlanSchema = z.object({
   type: z.enum(['bar', 'line', 'area', 'pie']).describe('Preferred visualization type.'),
   xKey: z.string().describe('Field to use for the horizontal axis or category.'),
+  xLabel: z.string().optional().describe('Label to display underneath the X-axis.'),
+  yLabel: z.string().optional().describe('Label to display beside the primary Y-axis.'),
+  yLabelSecondary: z
+    .string()
+    .optional()
+    .describe('Label to display beside the secondary Y-axis when one is required.'),
   series: z.array(chartSeriesSchema).min(1).describe('One or more data series to render.'),
   title: z.string().optional().describe('Suggested title for the chart.'),
   description: z.string().optional().describe('Short narrative explaining what the chart shows.'),
@@ -46,10 +67,12 @@ ${JSON.stringify(input.dataPreview, null, 2)}
 
 REQUIREMENTS:
 - Pick the most appropriate chart type among bar, line, area, or pie.
-- Use column names exactly as they appear in the data preview.
+- Use column names exactly as they appear in the data preview. If you need to rename a series, keep the original column name in "dataKey" and use "key" for the rendered label.
 - Respond strictly as JSON that matches the provided schema.
-- Prefer grouped/stacked charts if multiple metrics share the same categories.
+- Prefer grouped/stacked charts if multiple metrics share the same categories (set "stackId" when stacking is desired).
+- Use the "axis" property to place specific series on a secondary Y-axis when scales differ substantially.
 - Provide a concise title and description when helpful.
+- Include axis labels when they improve readability.
 `;
 
     const response = await ai.generate({

--- a/src/components/chat-visualization.tsx
+++ b/src/components/chat-visualization.tsx
@@ -8,7 +8,21 @@ import {
   ChartLegend,
   ChartLegendContent,
 } from '@/src/components/ui/chart';
-import { CartesianGrid, XAxis, YAxis, BarChart, Bar, LineChart, Line, AreaChart, Area, PieChart, Pie, Cell } from 'recharts';
+import {
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  AreaChart,
+  Area,
+  PieChart,
+  Pie,
+  Cell,
+  Label,
+} from 'recharts';
 import type { ChartDefinition } from '@/src/lib/types';
 import { cn } from '@/src/lib/utils';
 
@@ -29,12 +43,25 @@ function humanize(label: string): string {
     .replace(/^\w/g, (char) => char.toUpperCase());
 }
 
-function buildChartConfig(chart: ChartDefinition) {
-  return chart.series.reduce<Record<string, { label?: React.ReactNode; color?: string }>>(
+type ResolvedSeries = ChartDefinition['series'][number] & {
+  color: string;
+  dataKey: string;
+};
+
+function resolveSeries(chart: ChartDefinition): ResolvedSeries[] {
+  return chart.series.map((series, index) => ({
+    ...series,
+    color: series.color ?? chartPalette[index % chartPalette.length],
+    dataKey: series.dataKey ?? series.key,
+  }));
+}
+
+function buildChartConfig(series: ResolvedSeries[]) {
+  return series.reduce<Record<string, { label?: React.ReactNode; color?: string }>>(
     (acc, series, index) => {
       acc[series.key] = {
         label: series.label ?? humanize(series.key),
-        color: chartPalette[index % chartPalette.length],
+        color: series.color ?? chartPalette[index % chartPalette.length],
       };
       return acc;
     },
@@ -42,16 +69,51 @@ function buildChartConfig(chart: ChartDefinition) {
   );
 }
 
-function normalizeData(chart: ChartDefinition) {
+function getValue(row: Record<string, unknown>, key: string) {
+  if (key in row) {
+    return row[key];
+  }
+
+  if (key.includes('.')) {
+    return key.split('.').reduce<unknown>((acc, segment) => {
+      if (acc && typeof acc === 'object' && segment in (acc as Record<string, unknown>)) {
+        return (acc as Record<string, unknown>)[segment];
+      }
+      return undefined;
+    }, row);
+  }
+
+  return undefined;
+}
+
+function coerceNumeric(value: unknown) {
+  if (typeof value === 'number' || value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return value;
+    }
+
+    const normalized = trimmed.replace(/[^0-9+\-Ee.]/g, '');
+    if (normalized && !Number.isNaN(Number(normalized))) {
+      return Number(normalized);
+    }
+  }
+
+  return value;
+}
+
+function normalizeData(chart: ChartDefinition, series: ResolvedSeries[]) {
   return chart.data.map((row) => {
     const normalized: Record<string, unknown> = { ...row };
-    chart.series.forEach((series) => {
-      const value = (row as Record<string, unknown>)[series.key];
-      if (typeof value === 'string') {
-        const numeric = Number(value);
-        if (!Number.isNaN(numeric)) {
-          normalized[series.key] = numeric;
-        }
+    series.forEach((series) => {
+      const sourceValue = getValue(row as Record<string, unknown>, series.dataKey);
+      const numeric = coerceNumeric(sourceValue);
+      if (numeric !== undefined) {
+        normalized[series.key] = numeric;
       }
     });
     return normalized;
@@ -64,15 +126,53 @@ interface ChatVisualizationProps {
 }
 
 export function ChatVisualization({ chart, className }: ChatVisualizationProps) {
-  const config = React.useMemo(() => buildChartConfig(chart), [chart]);
-  const data = React.useMemo(() => normalizeData(chart), [chart]);
+  const resolvedSeries = React.useMemo(() => resolveSeries(chart), [chart]);
+  const config = React.useMemo(() => buildChartConfig(resolvedSeries), [resolvedSeries]);
+  const data = React.useMemo(() => normalizeData(chart, resolvedSeries), [chart, resolvedSeries]);
+  const hasSecondaryAxis = React.useMemo(
+    () => resolvedSeries.some((series) => series.axis === 'right'),
+    [resolvedSeries],
+  );
 
   const renderCartesian = (type: 'bar' | 'line' | 'area') => {
     const commonAxes = (
       <>
         <CartesianGrid strokeDasharray="3 3" vertical={false} />
-        <XAxis dataKey={chart.xKey} tickLine={false} axisLine={false} />
-        <YAxis tickLine={false} axisLine={false} width={48} />
+        <XAxis dataKey={chart.xKey} tickLine={false} axisLine={false}>
+          {chart.xLabel && (
+            <Label value={chart.xLabel} position="insideBottom" offset={-12} className="text-xs" />
+          )}
+        </XAxis>
+        <YAxis tickLine={false} axisLine={false} width={48} yAxisId="left">
+          {chart.yLabel && (
+            <Label
+              value={chart.yLabel}
+              position="insideLeft"
+              angle={-90}
+              offset={12}
+              className="text-xs"
+            />
+          )}
+        </YAxis>
+        {hasSecondaryAxis && (
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            width={48}
+            orientation="right"
+            yAxisId="right"
+          >
+            {chart.yLabelSecondary && (
+              <Label
+                value={chart.yLabelSecondary}
+                position="insideRight"
+                angle={90}
+                offset={12}
+                className="text-xs"
+              />
+            )}
+          </YAxis>
+        )}
         <ChartTooltip cursor={{ opacity: 0.2 }} content={<ChartTooltipContent />} />
         <ChartLegend content={<ChartLegendContent />} />
       </>
@@ -82,13 +182,16 @@ export function ChatVisualization({ chart, className }: ChatVisualizationProps) 
       return (
         <BarChart data={data}>
           {commonAxes}
-          {chart.series.map((series) => (
+          {resolvedSeries.map((series) => (
             <Bar
               key={series.key}
               dataKey={series.key}
-              fill={`var(--color-${series.key})`}
+              fill={series.color}
+              stroke={series.color}
               radius={4}
               maxBarSize={64}
+              stackId={series.stackId}
+              yAxisId={series.axis === 'right' ? 'right' : 'left'}
             />
           ))}
         </BarChart>
@@ -99,14 +202,15 @@ export function ChatVisualization({ chart, className }: ChatVisualizationProps) 
       return (
         <LineChart data={data}>
           {commonAxes}
-          {chart.series.map((series) => (
+          {resolvedSeries.map((series) => (
             <Line
               key={series.key}
               type="monotone"
               dataKey={series.key}
-              stroke={`var(--color-${series.key})`}
+              stroke={series.color}
               strokeWidth={2}
               dot={false}
+              yAxisId={series.axis === 'right' ? 'right' : 'left'}
             />
           ))}
         </LineChart>
@@ -116,14 +220,16 @@ export function ChatVisualization({ chart, className }: ChatVisualizationProps) 
     return (
       <AreaChart data={data}>
         {commonAxes}
-        {chart.series.map((series) => (
+        {resolvedSeries.map((series) => (
           <Area
             key={series.key}
             type="monotone"
             dataKey={series.key}
-            fill={`var(--color-${series.key})`}
-            stroke={`var(--color-${series.key})`}
+            fill={series.color}
+            stroke={series.color}
             fillOpacity={0.3}
+            stackId={series.stackId}
+            yAxisId={series.axis === 'right' ? 'right' : 'left'}
           />
         ))}
       </AreaChart>
@@ -131,7 +237,7 @@ export function ChatVisualization({ chart, className }: ChatVisualizationProps) 
   };
 
   const renderPie = () => {
-    const [series] = chart.series;
+    const [series] = resolvedSeries;
     return (
       <PieChart>
         <ChartTooltip content={<ChartTooltipContent />} />
@@ -147,7 +253,7 @@ export function ChatVisualization({ chart, className }: ChatVisualizationProps) 
           {data.map((_, index) => (
             <Cell
               key={`cell-${index}`}
-              fill={chartPalette[index % chartPalette.length]}
+              fill={series.color ?? chartPalette[index % chartPalette.length]}
               stroke="var(--border)"
             />
           ))}

--- a/src/components/history-panel.tsx
+++ b/src/components/history-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ScrollArea } from "@/src/components/ui/scroll-area";
-import type { Conversation } from '@/src/components/dashboard';
+import type { Conversation } from '@/src/lib/types';
 import { Button } from "@/src/components/ui/button";
 import { cn } from "@/src/lib/utils";
 

--- a/src/components/user-nav.tsx
+++ b/src/components/user-nav.tsx
@@ -33,6 +33,14 @@ export function UserNav({ user }: UserNavProps) {
 
   const handleLogout = async () => {
     try {
+      if (!auth) {
+        toast({
+          variant: "destructive",
+          title: "Logout Unavailable",
+          description: "Authentication is not configured for this environment.",
+        });
+        return;
+      }
       await signOut(auth);
       toast({
         title: "Logged Out",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,13 +1,39 @@
 import { z } from 'zod';
 
 export const ChartSeriesSchema = z.object({
-  key: z.string(),
-  label: z.string().optional(),
+  key: z
+    .string()
+    .describe('The key used for rendering the series in the visualization output.'),
+  label: z
+    .string()
+    .optional()
+    .describe('Human friendly label that should be displayed for the series.'),
+  dataKey: z
+    .string()
+    .optional()
+    .describe(
+      'Optional raw field name to read values from. Useful when the rendered key should differ from the column name.',
+    ),
+  color: z
+    .string()
+    .optional()
+    .describe('Preferred color for the series (CSS color value such as hex, rgb, or hsl).'),
+  axis: z
+    .enum(['left', 'right'])
+    .optional()
+    .describe('Selects the Y-axis to use when rendering multi-axis charts.'),
+  stackId: z
+    .string()
+    .optional()
+    .describe('Optional stack identifier for stacked visualizations.'),
 });
 
 export const ChartDefinitionSchema = z.object({
   type: z.enum(['bar', 'line', 'area', 'pie']),
   xKey: z.string(),
+  xLabel: z.string().optional(),
+  yLabel: z.string().optional(),
+  yLabelSecondary: z.string().optional(),
   series: z.array(ChartSeriesSchema).min(1),
   title: z.string().optional(),
   description: z.string().optional(),

--- a/src/types/langchain.d.ts
+++ b/src/types/langchain.d.ts
@@ -1,0 +1,16 @@
+declare module 'langchain/text_splitter' {
+  type BaseParams = {
+    chunkSize?: number;
+    chunkOverlap?: number;
+  };
+
+  type SplitDocument = {
+    pageContent: string;
+    metadata?: Record<string, unknown>;
+  };
+
+  export class RecursiveCharacterTextSplitter {
+    constructor(params?: BaseParams);
+    createDocuments(input: string[]): Promise<SplitDocument[]>;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./src/*"],
+      "@/src/*": ["./src/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- extend visualization schemas to support richer chart metadata, series colors, stacking, and dual-axis guidance
- enhance chat visualization rendering to normalize values, support axis labels/secondary axes, and use configured colors
- fix type issues by correcting history panel imports, guarding auth logout, providing langchain typings, and aligning TS path aliases

## Testing
- yarn typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d588e9c1448332a402b2cfb4e18484