### PR TITLE
Trim Ask AI panel submissions before sending

### DIFF
--- a/src/components/ask-ai-panel.tsx
+++ b/src/components/ask-ai-panel.tsx
@@ -20,7 +20,10 @@ import { ChatVisualization } from '@/src/components/chat-visualization';
 import type { MainAssistantOutput } from '@/src/ai/flows/main-assistant-flow';
 
 const formSchema = z.object({
-  question: z.string().min(1, 'Question cannot be empty.'),
+  question: z
+    .string()
+    .transform(value => value.trim())
+    .pipe(z.string().min(1, 'Question cannot be empty.')),
 });
 
 interface AskAiPanelProps {
@@ -60,7 +63,9 @@ export default function AskAiPanel({ conversation, onMessagesUpdate }: AskAiPane
   });
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
-    const userMessage: Message = { role: 'user', content: values.question };
+    const question = values.question.trim();
+
+    const userMessage: Message = { role: 'user', content: question };
     const newMessages = [...messagesRef.current, userMessage];
     let latestMessages = newMessages;
 
@@ -109,7 +114,7 @@ export default function AskAiPanel({ conversation, onMessagesUpdate }: AskAiPane
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          question: values.question,
+          question,
           history: historyForApi,
         }),
       });


### PR DESCRIPTION
## Summary
- trim Ask AI form input before validating so whitespace-only questions are rejected
- send the trimmed question to the assistant when persisting history and performing requests

## Testing
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68d58de5821c8332b6edc9bd5ec5aeb6