### PR TITLE
Fix Vega renderer imports by externalizing dependencies

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -24,6 +24,9 @@ const nextConfig: NextConfig = {
       }
     ],
   },
+  experimental: {
+    serverComponentsExternalPackages: ['@resvg/resvg-js', 'vega', 'vega-lite', 'canvas'],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- ensure the Next.js build keeps Vega-related packages external so the server-side renderer can load them without module errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daa6428e708332bc39fe8707f18078