### PR TITLE
Handle missing AI configuration gracefully

### DIFF
--- a/src/ai/flows/main-assistant-flow.ts
+++ b/src/ai/flows/main-assistant-flow.ts
@@ -40,6 +40,44 @@ export type MainAssistantOutput = z.infer<typeof MainAssistantOutputSchema>;
 
 export async function mainAssistant(input: MainAssistantInput): Promise<MainAssistantOutput> {
   noStore();
+  const missingEnvVars: string[] = [];
+
+  if (!process.env.OPENAI_API_KEY || process.env.OPENAI_API_KEY.trim().length === 0) {
+    missingEnvVars.push('OPENAI_API_KEY');
+  }
+
+  const missingSupabaseValues: string[] = [];
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL.trim().length === 0) {
+    missingSupabaseValues.push('NEXT_PUBLIC_SUPABASE_URL');
+  }
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY.trim().length === 0
+  ) {
+    missingSupabaseValues.push('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  }
+
+  if (missingSupabaseValues.length > 0) {
+    console.warn(
+      '[mainAssistant] Supabase environment variables are missing. Database-backed questions will fail until they are configured.',
+      missingSupabaseValues,
+    );
+  }
+
+  if (missingEnvVars.length > 0) {
+    const message =
+      'The AI assistant service is not configured. Please provide the required environment variables before using this feature. ' +
+      `Missing: ${missingEnvVars.join(', ')}.`;
+    console.error('[mainAssistant] Missing required configuration:', missingEnvVars);
+
+    return {
+      answer: message,
+      sqlQuery: undefined,
+      retrievedContext: undefined,
+      chart: undefined,
+    };
+  }
+
   const result = await mainAssistantFlow(input);
   console.log('[mainAssistant] Returning from mainAssistant:', JSON.stringify(result, null, 2));
   return result;


### PR DESCRIPTION
## Summary
- prevent the main assistant flow from running when required AI configuration is missing
- log a clear warning when Supabase environment variables are absent so database questions can be diagnosed quickly

## Testing
- yarn lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68daa6f580688332860d3936153f6686