### PR TITLE
Implement Vega visualization pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-toast": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.1.8",
+    "@tanstack/query-core": "^5.62.9",
+    "@tanstack/react-query": "^5.62.9",
     "@resvg/resvg-js": "^2.6.2",
     "@supabase/supabase-js": "^2.45.0",
     "canvas": "^2.11.2",
@@ -73,7 +75,9 @@
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^10.0.0",
     "vega": "^6.1.2",
+    "vega-embed": "^6.26.0",
     "vega-lite": "^6.2.0",
+    "zustand": "^4.5.5",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/src/ai/flows/main-assistant-flow.ts
+++ b/src/ai/flows/main-assistant-flow.ts
@@ -17,9 +17,11 @@ import { z } from 'zod';
 import { executeQueryTool } from '@/src/ai/tools/sql-query-tool';
 import { searchCodebook } from '@/src/lib/vector-search';
 import { statisticsTool } from '@/src/ai/tools/statistics-tool';
+import { generateVisualization } from '@/src/features/charting/server/generate-visualization';
+import { VisualizationChartMessageSchema } from '@/src/features/charting/types';
+import { randomUUID } from 'crypto';
 
 // ✨ NEU: Chart-Tool importieren
-import { chartTool } from '@/src/ai/tools/chart-tool';
 
 // ✨ NEU: Heuristik, ob die Frage nach einer Grafik klingt
 const looksLikeChart = (q: string) =>
@@ -40,6 +42,7 @@ const MainAssistantOutputSchema = z.object({
   answer: z.string().describe('The final answer to be displayed to the user.'),
   sqlQuery: z.string().optional().describe('The SQL query that was executed.'),
   retrievedContext: z.string().optional().describe('The context retrieved from the vector database.'),
+  chart: VisualizationChartMessageSchema.optional(),
 });
 export type MainAssistantOutput = z.infer<typeof MainAssistantOutputSchema>;
 
@@ -107,36 +110,37 @@ const mainAssistantFlow = ai.defineFlow(
 
     // ✨ NEU: Direkt nach der Reformulierung – Chart-Fall vorziehen
     if (looksLikeChart(reformulatedQuestion)) {
-      console.log('[mainAssistantFlow] Chart intent detected. Delegating to chartTool...');
-      const chart = await chartTool({
+      console.log('[mainAssistantFlow] Chart intent detected. Generating visualization payload...');
+      const clientChartId = randomUUID();
+      const visualization = await generateVisualization({
         nlQuestion: reformulatedQuestion,
         history: input.history,
+        clientChartId,
       });
 
-      if (chart.error) {
+      if (visualization.status === 'error' || !visualization.chart || !visualization.meta?.request) {
         return {
           answer:
-            `Die Grafik konnte nicht erzeugt werden:\n${chart.error}\n\n` +
-            `Vorschlag: Formuliere kurz, *welche* Variable(n) auf welche Achsen sollen und ggf. Gruppierung ` +
-            `(z. B. "Durchschnitt von trstprl nach cntry").`,
-          retrievedContext: chart.retrievedContext || undefined,
-          sqlQuery: chart.sqlQuery || undefined,
+            `Die Grafik konnte nicht erzeugt werden.\n${visualization.error?.message ?? ''}\n\n` +
+            `Tipp: Beschreibe knapp, welche Variablen auf die Achsen sollen und welche Aggregation du erwartest.`,
+          retrievedContext: visualization.chart?.retrievedContext,
+          sqlQuery: visualization.chart?.sqlQuery,
         };
       }
 
-      // Wenn du Bilder bevorzugst (data URL), direkt als Markdown zurückgeben:
-      const imgMd = chart.imageDataUrl
-        ? `![${chart.title || 'Chart'}](${chart.imageDataUrl})`
-        : '';
-
-      const specNote = chart.vegaLiteSpec
-        ? '\n\n*(Technik: Vega-Lite Spec wurde erzeugt; du kannst sie im Frontend auch clientseitig rendern.)*'
-        : '';
+      const caption =
+        visualization.chart.caption ??
+        'Hier ist die automatisch generierte Visualisierung. Du kannst sie mit den Tools im Interface weiter anpassen.';
 
       return {
-        answer: `${chart.caption || 'Hier ist die gewünschte Grafik.'}\n\n${imgMd}${specNote}`,
-        sqlQuery: chart.sqlQuery,
-        retrievedContext: chart.retrievedContext,
+        answer: caption,
+        sqlQuery: visualization.chart.sqlQuery,
+        retrievedContext: visualization.chart.retrievedContext,
+        chart: {
+          ...visualization.chart,
+          id: visualization.chart.id,
+          request: visualization.meta.request,
+        },
       };
     }
 

--- a/src/app/api/internal/viz/route.ts
+++ b/src/app/api/internal/viz/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  VisualizationRequestSchema,
+  VisualizationResponseSchema,
+} from '@/src/features/charting/types';
+import { generateVisualization } from '@/src/features/charting/server/generate-visualization';
+
+export async function POST(request: NextRequest) {
+  const payload = await request.json().catch(() => null);
+
+  const parseResult = VisualizationRequestSchema.safeParse(payload);
+
+  if (!parseResult.success) {
+    return NextResponse.json(
+      {
+        status: 'error',
+        error: {
+          message: 'Ungültige Anfrage für die Visualisierung.',
+          details: parseResult.error.flatten(),
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const visualization = await generateVisualization(parseResult.data);
+
+  const responseValidation = VisualizationResponseSchema.safeParse(visualization);
+
+  if (!responseValidation.success) {
+    return NextResponse.json(
+      {
+        status: 'error',
+        error: {
+          message: 'Die Visualisierung konnte nicht validiert werden.',
+          details: responseValidation.error.flatten(),
+        },
+      },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json(responseValidation.data, {
+    status: visualization.status === 'success' ? 200 : 500,
+  });
+}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import './globals.css';
 import { Toaster } from '@/src/components/ui/toaster';
 import localFont from 'next/font/local';
+import { AppProviders } from '@/src/components/app-providers';
 
 export const metadata: Metadata = {
   title: 'ESS Navigator',
@@ -29,7 +30,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" suppressHydrationWarning className={`${bodyFont.variable} ${headingFont.variable}`}>
       <body className="font-body antialiased">
-        {children}
+        <AppProviders>{children}</AppProviders>
         <Toaster />
       </body>
     </html>

--- a/src/components/app-providers.tsx
+++ b/src/components/app-providers.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { ReactNode, useState } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+interface AppProvidersProps {
+  children: ReactNode;
+}
+
+export function AppProviders({ children }: AppProvidersProps) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+            staleTime: 60_000,
+          },
+        },
+      }),
+  );
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+

--- a/src/components/ask-ai-panel.tsx
+++ b/src/components/ask-ai-panel.tsx
@@ -16,6 +16,8 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/src/components/ui/avatar"
 import { Loader2, Send, Code2, Database } from "lucide-react";
 import { type Conversation, type Message } from "@/src/lib/types";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/src/components/ui/accordion";
+import { ChartShell } from "@/src/features/charting/components/chart-shell";
+import { VegaChart } from "@/src/features/charting/components/vega-chart";
 
 interface InlineRenderResult {
   nodes: React.ReactNode[];
@@ -438,6 +440,7 @@ export default function AskAiPanel({ conversation, onMessagesUpdate }: AskAiPane
         content: result.answer, // kann Markdown + data:image/png enthalten
         sqlQuery: result.sqlQuery,
         retrievedContext: result.retrievedContext,
+        chart: result.chart,
       };
 
       const finalMessages = [...newMessages, assistantMessage];
@@ -512,6 +515,25 @@ export default function AskAiPanel({ conversation, onMessagesUpdate }: AskAiPane
                         alt="Chart"
                         className="max-w-full h-auto rounded-md shadow-sm"
                       />
+                    </div>
+                  )}
+
+                  {message.role === "assistant" && message.chart && (
+                    <div className="mt-4 space-y-3">
+                      <ChartShell title={message.chart.title} caption={message.chart.caption}>
+                        <VegaChart
+                          chartId={message.chart.id}
+                          request={message.chart.request}
+                          initialChart={{
+                            id: message.chart.id,
+                            config: message.chart.config,
+                            title: message.chart.title,
+                            caption: message.chart.caption,
+                            sqlQuery: message.chart.sqlQuery,
+                            retrievedContext: message.chart.retrievedContext,
+                          }}
+                        />
+                      </ChartShell>
                     </div>
                   )}
 

--- a/src/components/sql-tool-panel.tsx
+++ b/src/components/sql-tool-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
@@ -11,8 +11,13 @@ import { Textarea } from '@/src/components/ui/textarea';
 import { Button } from '@/src/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/src/components/ui/card";
 import { Loader2, Play } from 'lucide-react';
-import { DataTable } from './data-table';
 import { useToast } from '@/src/hooks/use-toast';
+import { DataTable } from './data-table';
+import { ChartShell } from '@/src/features/charting/components/chart-shell';
+import { VegaChart } from '@/src/features/charting/components/vega-chart';
+import { useChartStore } from '@/src/features/charting/state/chart-store';
+import { useChartQuery } from '@/src/features/charting/state/use-chart-query';
+import { VisualizationRequest } from '@/src/features/charting/types';
 
 const formSchema = z.object({
   query: z.string().min(1, 'Query cannot be empty.'),
@@ -26,7 +31,23 @@ interface QueryResult {
 export default function SqlToolPanel() {
   const [isLoading, setIsLoading] = useState(false);
   const [result, setResult] = useState<QueryResult | null>(null);
+  const [chartDescriptor, setChartDescriptor] = useState<
+    { id: string; request: VisualizationRequest } | null
+  >(null);
   const { toast } = useToast();
+  const resetChartStore = useChartStore((state) => state.reset);
+  const chartEntry = useChartStore((state) =>
+    chartDescriptor ? state.items[chartDescriptor.id] : undefined,
+  );
+
+  const chartId = chartDescriptor?.id ?? 'sql-tool-placeholder';
+  const chartRequest = chartDescriptor?.request ?? { nlQuestion: 'placeholder' };
+
+  useChartQuery({
+    chartId,
+    request: chartRequest,
+    enabled: Boolean(chartDescriptor),
+  });
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -35,9 +56,17 @@ export default function SqlToolPanel() {
     },
   });
 
+  const resetVisualization = useCallback(() => {
+    if (chartDescriptor) {
+      resetChartStore(chartDescriptor.id);
+    }
+    setChartDescriptor(null);
+  }, [chartDescriptor, resetChartStore]);
+
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setIsLoading(true);
     setResult(null);
+    resetVisualization();
 
     try {
       const queryResult = await executeQuery(values.query);
@@ -51,12 +80,28 @@ export default function SqlToolPanel() {
         if (queryResult.data.length > 0) {
             const columns = Object.keys(queryResult.data[0]);
             setResult({ columns, data: queryResult.data });
+
+            const newChartId = crypto.randomUUID();
+            const visualizationRequest: VisualizationRequest = {
+              nlQuestion:
+                'Erzeuge eine aussagekräftige Visualisierung aus den ESS-Daten für die folgende SQL-Abfrage. Nutze die Abfrage unverändert und wähle einen geeigneten Chart-Typ.',
+              history: [
+                {
+                  role: 'user',
+                  content: values.query,
+                },
+              ],
+              clientChartId: newChartId,
+            };
+
+            setChartDescriptor({ id: newChartId, request: visualizationRequest });
         } else {
              toast({
                 title: "Query Successful",
                 description: "The query ran successfully but returned no results.",
             });
             setResult({ columns: [], data: [] });
+            resetVisualization();
         }
       }
     } catch (error: any) {
@@ -65,6 +110,7 @@ export default function SqlToolPanel() {
             title: "An Unexpected Error Occurred",
             description: error.message || "Please check the console for more details.",
         });
+        resetVisualization();
     } finally {
       setIsLoading(false);
     }
@@ -114,6 +160,22 @@ export default function SqlToolPanel() {
                 ) : (
                     <p className="text-sm text-muted-foreground">Run a query to see the results here.</p>
                 )}
+            </div>
+
+            <div className="mt-6">
+              <h3 className="text-lg font-medium mb-2 font-headline">Visualization</h3>
+              {chartDescriptor ? (
+                <ChartShell
+                  title={chartEntry?.chart?.title ?? 'Automatisch generierte Visualisierung'}
+                  caption={chartEntry?.chart?.caption}
+                >
+                  <VegaChart chartId={chartDescriptor.id} request={chartDescriptor.request} />
+                </ChartShell>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Run a query to trigger an AI-generated visualization.
+                </p>
+              )}
             </div>
 
         </CardContent>

--- a/src/features/charting/api/fetch-chart.ts
+++ b/src/features/charting/api/fetch-chart.ts
@@ -1,0 +1,37 @@
+import {
+  VisualizationRequest,
+  VisualizationResponse,
+  VisualizationResponseSchema,
+} from '@/src/features/charting/types';
+
+interface FetchChartOptions {
+  signal?: AbortSignal;
+}
+
+export async function fetchChart(
+  request: VisualizationRequest,
+  options?: FetchChartOptions,
+): Promise<VisualizationResponse> {
+  const response = await fetch('/api/internal/viz', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+    signal: options?.signal,
+  });
+
+  const json = await response.json().catch(() => null);
+
+  const parsed = VisualizationResponseSchema.safeParse(json);
+
+  if (!parsed.success) {
+    throw new Error('Die Visualisierung konnte nicht geladen werden.');
+  }
+
+  if (!response.ok || parsed.data.status === 'error') {
+    const message = parsed.data.error?.message ?? 'Die Visualisierung schlug fehl.';
+    throw new Error(message);
+  }
+
+  return parsed.data;
+}
+

--- a/src/features/charting/components/chart-shell.tsx
+++ b/src/features/charting/components/chart-shell.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { cn } from '@/src/lib/utils';
+
+interface ChartShellProps {
+  title?: string;
+  caption?: string;
+  actions?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+export function ChartShell({
+  title,
+  caption,
+  actions,
+  children,
+  className,
+}: ChartShellProps) {
+  return (
+    <div className={cn('rounded-lg border bg-background shadow-sm', className)}>
+      <div className="flex flex-col gap-2 border-b px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="font-medium text-sm sm:text-base">
+            {title ?? 'Automatisch generierte Visualisierung'}
+          </p>
+          {caption && <p className="text-xs text-muted-foreground sm:text-sm">{caption}</p>}
+        </div>
+        {actions}
+      </div>
+      <div className="px-4 py-3">{children}</div>
+    </div>
+  );
+}
+

--- a/src/features/charting/components/vega-chart.tsx
+++ b/src/features/charting/components/vega-chart.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import vegaEmbed, { VisualizationSpec } from 'vega-embed';
+import { useChartStore } from '@/src/features/charting/state/chart-store';
+import { useChartQuery } from '@/src/features/charting/state/use-chart-query';
+import { VisualizationChart, VisualizationRequest } from '@/src/features/charting/types';
+
+interface VegaChartProps {
+  chartId: string;
+  request: VisualizationRequest;
+  initialChart?: VisualizationChart;
+  className?: string;
+}
+
+export function VegaChart({ chartId, request, initialChart, className }: VegaChartProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const viewRef = useRef<vegaEmbed.Result | null>(null);
+  const [embeddingError, setEmbeddingError] = useState<string | null>(null);
+
+  const query = useChartQuery({ chartId, request, initialChart, enabled: Boolean(chartId && request) });
+
+  const chartEntry = useChartStore((state) => state.items[chartId]);
+
+  const chartConfig = useMemo(() => chartEntry?.chart?.config as VisualizationSpec | undefined, [chartEntry]);
+
+  useEffect(() => {
+    if (!chartConfig || !containerRef.current) {
+      return;
+    }
+
+    let cancelled = false;
+    setEmbeddingError(null);
+
+    const element = containerRef.current;
+
+    vegaEmbed(element, chartConfig, {
+      actions: false,
+      renderer: 'canvas',
+      config: { font: 'var(--font-body)' },
+    })
+      .then((result) => {
+        if (cancelled) {
+          result.view.finalize();
+          return;
+        }
+        viewRef.current = result;
+      })
+      .catch((error: any) => {
+        setEmbeddingError(error?.message ?? 'Das Chart konnte nicht angezeigt werden.');
+      });
+
+    return () => {
+      cancelled = true;
+      if (viewRef.current) {
+        viewRef.current.view.finalize();
+        viewRef.current = null;
+      }
+      if (element) {
+        element.innerHTML = '';
+      }
+    };
+  }, [chartConfig]);
+
+  useEffect(() => {
+    const view = viewRef.current?.view;
+    const element = containerRef.current;
+
+    if (!view || !element) {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      view.resize().runAsync();
+    });
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [chartConfig]);
+
+  if (embeddingError) {
+    return (
+      <div className="text-sm text-destructive">
+        {embeddingError}
+      </div>
+    );
+  }
+
+  if (chartEntry?.status === 'error') {
+    return (
+      <div className="text-sm text-destructive">
+        {chartEntry.error ?? 'Die Visualisierung ist fehlgeschlagen.'}
+      </div>
+    );
+  }
+
+  if (!chartConfig) {
+    return (
+      <div className="flex h-48 items-center justify-center">
+        <span className="text-sm text-muted-foreground">
+          {query.isLoading ? 'Visualisierung wird geladen …' : 'Noch keine Visualisierung verfügbar.'}
+        </span>
+      </div>
+    );
+  }
+
+  return <div ref={containerRef} className={className} />;
+}
+

--- a/src/features/charting/server/generate-visualization.ts
+++ b/src/features/charting/server/generate-visualization.ts
@@ -1,0 +1,107 @@
+import { chartTool } from '@/src/ai/tools/chart-tool';
+import { isAiConfigured, missingAiMessage } from '@/src/ai/genkit';
+import { VisualizationRequest, VisualizationResponse } from '@/src/features/charting/types';
+import { randomUUID } from 'crypto';
+
+async function validateVegaLiteSpec(spec: any): Promise<void> {
+  if (!spec) return;
+  const [vegaLiteModule, vegaModule] = await Promise.all([
+    import('vega-lite'),
+    import('vega'),
+  ]);
+
+  const vegaLite = (vegaLiteModule as any).default ?? vegaLiteModule;
+  const vega = (vegaModule as any).default ?? vegaModule;
+
+  const compiled = vegaLite.compile(spec).spec;
+  vega.parse(compiled);
+}
+
+export async function generateVisualization(
+  request: VisualizationRequest,
+): Promise<VisualizationResponse> {
+  if (!isAiConfigured) {
+    return {
+      status: 'error',
+      error: {
+        message: missingAiMessage,
+      },
+      meta: {
+        generatedAt: new Date().toISOString(),
+        request,
+      },
+    };
+  }
+
+  try {
+    const chart = await chartTool({
+      nlQuestion: request.nlQuestion,
+      history: request.history,
+    });
+
+    if (chart.error) {
+      return {
+        status: 'error',
+        error: {
+          message: chart.error,
+        },
+        meta: {
+          generatedAt: new Date().toISOString(),
+          request,
+        },
+      };
+    }
+
+    if (!chart.vegaLiteSpec) {
+      return {
+        status: 'error',
+        error: {
+          message: 'Das Chart-Tool lieferte keine Vega-Lite-Spezifikation zurück.',
+        },
+        meta: {
+          generatedAt: new Date().toISOString(),
+          request,
+        },
+      };
+    }
+
+    await validateVegaLiteSpec(chart.vegaLiteSpec);
+
+    const chartId = request.clientChartId ?? randomUUID();
+
+    return {
+      status: 'success',
+      chart: {
+        id: chartId,
+        config: chart.vegaLiteSpec,
+        title: chart.title,
+        caption: chart.caption,
+        sqlQuery: chart.sqlQuery ?? undefined,
+        retrievedContext: chart.retrievedContext ?? undefined,
+      },
+      meta: {
+        generatedAt: new Date().toISOString(),
+        request: { ...request, clientChartId: chartId },
+      },
+    };
+  } catch (error: any) {
+    const message =
+      typeof error?.message === 'string'
+        ? error.message
+        : 'Unbekannter Fehler beim Generieren der Visualisierung.';
+
+    return {
+      status: 'error',
+      error: {
+        message,
+        details:
+          error && typeof error === 'object' ? JSON.stringify(error, null, 2) : undefined,
+      },
+      meta: {
+        generatedAt: new Date().toISOString(),
+        request,
+      },
+    };
+  }
+}
+

--- a/src/features/charting/state/chart-store.ts
+++ b/src/features/charting/state/chart-store.ts
@@ -1,0 +1,63 @@
+import { create } from 'zustand';
+import { VisualizationChart } from '@/src/features/charting/types';
+
+export type ChartStatus = 'idle' | 'loading' | 'success' | 'error';
+
+export interface ChartEntry {
+  status: ChartStatus;
+  chart?: VisualizationChart;
+  error?: string;
+}
+
+interface ChartStoreState {
+  items: Record<string, ChartEntry>;
+  setLoading: (id: string) => void;
+  setSuccess: (id: string, chart: VisualizationChart) => void;
+  setError: (id: string, error: string) => void;
+  reset: (id?: string) => void;
+}
+
+export const useChartStore = create<ChartStoreState>((set) => ({
+  items: {},
+  setLoading: (id) =>
+    set((state) => ({
+      items: {
+        ...state.items,
+        [id]: {
+          status: 'loading',
+          chart: state.items[id]?.chart,
+        },
+      },
+    })),
+  setSuccess: (id, chart) =>
+    set((state) => ({
+      items: {
+        ...state.items,
+        [id]: {
+          status: 'success',
+          chart,
+        },
+      },
+    })),
+  setError: (id, error) =>
+    set((state) => ({
+      items: {
+        ...state.items,
+        [id]: {
+          status: 'error',
+          error,
+        },
+      },
+    })),
+  reset: (id) =>
+    set((state) => {
+      if (!id) {
+        return { items: {} };
+      }
+
+      const next = { ...state.items };
+      delete next[id];
+      return { items: next };
+    }),
+}));
+

--- a/src/features/charting/state/use-chart-query.ts
+++ b/src/features/charting/state/use-chart-query.ts
@@ -1,0 +1,74 @@
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchChart } from '@/src/features/charting/api/fetch-chart';
+import {
+  VisualizationChart,
+  VisualizationResponse,
+  VisualizationRequest,
+} from '@/src/features/charting/types';
+import { useChartStore } from '@/src/features/charting/state/chart-store';
+
+interface UseChartQueryParams {
+  chartId: string;
+  request: VisualizationRequest;
+  initialChart?: VisualizationChart;
+  enabled?: boolean;
+}
+
+export function useChartQuery({
+  chartId,
+  request,
+  initialChart,
+  enabled = true,
+}: UseChartQueryParams) {
+  const setLoading = useChartStore((state) => state.setLoading);
+  const setSuccess = useChartStore((state) => state.setSuccess);
+  const setError = useChartStore((state) => state.setError);
+
+  const query = useQuery<VisualizationResponse, Error>({
+    queryKey: ['chart', chartId],
+    queryFn: ({ signal }) => fetchChart({ ...request, clientChartId: chartId }, { signal }),
+    staleTime: 60_000,
+    retry: 1,
+    enabled,
+    initialData: initialChart
+      ? {
+          status: 'success',
+          chart: { ...initialChart, id: chartId },
+          meta: {
+            generatedAt: new Date().toISOString(),
+            request: { ...request, clientChartId: chartId },
+          },
+        }
+      : undefined,
+  });
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    if (query.isFetching) {
+      setLoading(chartId);
+    }
+  }, [chartId, enabled, query.isFetching, setLoading]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    if (query.data?.status === 'success' && query.data.chart) {
+      setSuccess(chartId, { ...query.data.chart, id: chartId });
+    }
+
+    if (query.isError) {
+      setError(chartId, query.error.message);
+    } else if (query.data?.status === 'error' && query.data.error) {
+      setError(chartId, query.data.error.message);
+    }
+  }, [chartId, enabled, query.data, query.error, query.isError, setError, setSuccess]);
+
+  return query;
+}
+

--- a/src/features/charting/types.ts
+++ b/src/features/charting/types.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+const ConversationTurnSchema = z.object({
+  role: z.enum(['user', 'assistant', 'tool']),
+  content: z.string(),
+});
+
+export const VisualizationRequestSchema = z.object({
+  nlQuestion: z.string().min(3, 'A natural language question is required.'),
+  history: z.array(ConversationTurnSchema).optional(),
+  clientChartId: z.string().optional(),
+});
+export type VisualizationRequest = z.infer<typeof VisualizationRequestSchema>;
+
+export const VisualizationErrorSchema = z.object({
+  message: z.string(),
+  details: z.string().optional(),
+});
+export type VisualizationError = z.infer<typeof VisualizationErrorSchema>;
+
+export const VisualizationChartSchema = z.object({
+  id: z.string(),
+  config: z.any(),
+  title: z.string().optional(),
+  caption: z.string().optional(),
+  sqlQuery: z.string().optional(),
+  retrievedContext: z.string().optional(),
+});
+export type VisualizationChart = z.infer<typeof VisualizationChartSchema>;
+
+export const VisualizationResponseSchema = z.object({
+  status: z.enum(['success', 'error']),
+  chart: VisualizationChartSchema.optional(),
+  error: VisualizationErrorSchema.optional(),
+  meta: z
+    .object({
+      generatedAt: z.string(),
+      request: VisualizationRequestSchema,
+    })
+    .optional(),
+});
+export type VisualizationResponse = z.infer<typeof VisualizationResponseSchema>;
+
+export const VisualizationChartMessageSchema = VisualizationChartSchema.extend({
+  request: VisualizationRequestSchema,
+});
+export type VisualizationChartMessage = z.infer<typeof VisualizationChartMessageSchema>;
+

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { VisualizationChartMessageSchema } from '@/src/features/charting/types';
 
 /**
  * Defines the structure for a single message in a conversation.
@@ -9,6 +10,7 @@ export const MessageSchema = z.object({
   content: z.string(),
   sqlQuery: z.string().optional(),
   retrievedContext: z.string().optional(),
+  chart: VisualizationChartMessageSchema.optional(),
 });
 export type Message = z.infer<typeof MessageSchema>;
 


### PR DESCRIPTION
## Summary
- add an internal /api/internal/viz endpoint that wraps the existing chart tool and validates Vega-Lite output
- introduce shared charting utilities (React Query hook, Zustand store, Vega renderer components) for consistent client-side rendering
- wire chat and SQL panels to the new visualization pipeline and wrap the app in a shared query client provider

## Testing
- Not run (environment only)


------
https://chatgpt.com/codex/tasks/task_e_68e662d7134883328b27867a4d714d12