### PR TITLE
Replace TanStack React Query usage with custom chart query hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,6 @@
     "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-toast": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.1.8",
-    "@tanstack/query-core": "^5.62.9",
-    "@tanstack/react-query": "^5.62.9",
     "@resvg/resvg-js": "^2.6.2",
     "@supabase/supabase-js": "^2.45.0",
     "canvas": "^2.11.2",

--- a/src/components/app-providers.tsx
+++ b/src/components/app-providers.tsx
@@ -1,25 +1,12 @@
 'use client';
 
-import { ReactNode, useState } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode } from 'react';
 
 interface AppProvidersProps {
   children: ReactNode;
 }
 
 export function AppProviders({ children }: AppProvidersProps) {
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            refetchOnWindowFocus: false,
-            staleTime: 60_000,
-          },
-        },
-      }),
-  );
-
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  return <>{children}</>;
 }
 

--- a/src/features/charting/state/use-chart-query.ts
+++ b/src/features/charting/state/use-chart-query.ts
@@ -1,5 +1,4 @@
-import { useEffect } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
 import { fetchChart } from '@/src/features/charting/api/fetch-chart';
 import {
   VisualizationChart,
@@ -15,6 +14,13 @@ interface UseChartQueryParams {
   enabled?: boolean;
 }
 
+interface QueryState {
+  status: 'idle' | 'loading' | 'success' | 'error';
+  data?: VisualizationResponse;
+  error: Error | null;
+  isFetching: boolean;
+}
+
 export function useChartQuery({
   chartId,
   request,
@@ -25,23 +31,112 @@ export function useChartQuery({
   const setSuccess = useChartStore((state) => state.setSuccess);
   const setError = useChartStore((state) => state.setError);
 
-  const query = useQuery<VisualizationResponse, Error>({
-    queryKey: ['chart', chartId],
-    queryFn: ({ signal }) => fetchChart({ ...request, clientChartId: chartId }, { signal }),
-    staleTime: 60_000,
-    retry: 1,
-    enabled,
-    initialData: initialChart
-      ? {
-          status: 'success',
-          chart: { ...initialChart, id: chartId },
-          meta: {
-            generatedAt: new Date().toISOString(),
-            request: { ...request, clientChartId: chartId },
-          },
+  const initialData = useMemo<VisualizationResponse | undefined>(() => {
+    if (!initialChart) {
+      return undefined;
+    }
+
+    return {
+      status: 'success',
+      chart: { ...initialChart, id: chartId },
+      meta: {
+        generatedAt: new Date().toISOString(),
+        request: { ...request, clientChartId: chartId },
+      },
+    };
+  }, [chartId, initialChart, request]);
+
+  const [state, setState] = useState<QueryState>(() => ({
+    status: initialData ? 'success' : enabled ? 'loading' : 'idle',
+    data: initialData,
+    error: null,
+    isFetching: false,
+  }));
+
+  useEffect(() => {
+    if (!initialData) {
+      return;
+    }
+
+    setState((prev) => {
+      if (prev.data?.chart.id === initialData.chart.id) {
+        return prev;
+      }
+
+      return {
+        status: 'success',
+        data: initialData,
+        error: null,
+        isFetching: prev.isFetching,
+      };
+    });
+  }, [initialData]);
+
+  useEffect(() => {
+    if (!enabled || !chartId) {
+      setState((prev) => ({
+        ...prev,
+        isFetching: false,
+        status: prev.data ? 'success' : 'idle',
+      }));
+      return;
+    }
+
+    let isActive = true;
+    const controller = new AbortController();
+
+    setState((prev) => ({
+      ...prev,
+      status: prev.data ? 'success' : 'loading',
+      isFetching: true,
+      error: null,
+    }));
+
+    fetchChart({ ...request, clientChartId: chartId }, { signal: controller.signal })
+      .then((response) => {
+        if (!isActive) {
+          return;
         }
-      : undefined,
-  });
+
+        setState({
+          status: 'success',
+          data: response,
+          error: null,
+          isFetching: false,
+        });
+      })
+      .catch((error) => {
+        if (!isActive || error?.name === 'AbortError') {
+          return;
+        }
+
+        const normalizedError =
+          error instanceof Error ? error : new Error('Die Visualisierung konnte nicht geladen werden.');
+
+        setState((prev) => ({
+          status: 'error',
+          data: prev.data,
+          error: normalizedError,
+          isFetching: false,
+        }));
+      });
+
+    return () => {
+      isActive = false;
+      controller.abort();
+    };
+  }, [chartId, enabled, request]);
+
+  const query = useMemo(
+    () => ({
+      data: state.data,
+      error: state.error ?? undefined,
+      isError: state.status === 'error',
+      isLoading: state.status === 'loading' && !state.data,
+      isFetching: state.isFetching,
+    }),
+    [state],
+  );
 
   useEffect(() => {
     if (!enabled) {


### PR DESCRIPTION
## Summary
- remove the React Query provider and dependency that were causing module resolution failures
- reimplement the chart query hook with manual fetch handling, including initial data and store integration

## Testing
- yarn test *(fails: Vega renderer dependencies are not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e66c2721008332af1b6cb052193f72